### PR TITLE
Bump openstack-cpi-release to v37.

### DIFF
--- a/openstack/cpi.yml
+++ b/openstack/cpi.yml
@@ -3,8 +3,8 @@
   path: /releases/-
   value:
     name: bosh-openstack-cpi
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-openstack-cpi-release?v=36
-    sha1: 13a67e486b8c62dda48b13dd2b5c8ac16724934c
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-openstack-cpi-release?v=37
+    sha1: 4507b907955909bc8036afc1cf6be339b306ca03
 
 - type: replace
   path: /resource_pools/name=vms/stemcell?


### PR DESCRIPTION
https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/issues/111