### PR TITLE
Make keystone v3 the default for openstack

### DIFF
--- a/openstack/cpi.yml
+++ b/openstack/cpi.yml
@@ -45,7 +45,9 @@
     auth_url: ((auth_url))
     username: ((openstack_username))
     api_key: ((openstack_password))
-    tenant: ((tenant))
+    domain: ((openstack_domain))
+    project: ((openstack_project))
     region: ((region))
     default_key_name: ((default_key_name))
     default_security_groups: ((default_security_groups))
+    human_readable_vm_names: true


### PR DESCRIPTION
also enable human readable vm names by default