### PR TITLE
Bump gcp stemcell version to 3586.7

### DIFF
--- a/gcp/cpi.yml
+++ b/gcp/cpi.yml
@@ -9,8 +9,8 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell?
   value:
-    url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent?v=3468.17
-    sha1: 742b92355e9b81d9d071dbdc76f058e6e3e97753
+    url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent?v=3586.7
+    sha1: dddc8efc691f97f5e2597749b93b31fe8b4754db
 
 # Configure sizes
 - type: replace


### PR DESCRIPTION
A Qualys scan of a jumpbox VM reports that there are a number of vulnerabilities with the version of OpenSSH installed. Admittedly, many of these vulnerabilities have been patched for the openssh-server version (1:6.6p1-2ubuntu2.8) in bosh-google-kvm-ubuntu-trusty-go_agent stemcell version 3468.17. The following CVEs appear to only be patched in openssh-server version 1:6.6p1-2ubuntu2.10, which is installed in stemcell version 3586.7:

CVE-2016-10009
CVE-2016-10010
CVE-2016-10011
CVE-2016-10012