### PR TITLE
Update manifest to use blobstores key in env hash

### DIFF
--- a/jumpbox.yml
+++ b/jumpbox.yml
@@ -12,6 +12,10 @@ resource_pools:
   network: private
   env:
     bosh:
+      blobstores:
+      - provider: local
+        options:
+          blobstore_path: /var/vcap/micro_bosh/data/cache
       password: "*"
       mbus:
         cert: ((mbus_bootstrap_ssl))
@@ -53,7 +57,6 @@ cloud_provider:
   cert: ((mbus_bootstrap_ssl))
   properties:
     agent: {mbus: "https://mbus:((mbus_bootstrap_password))@0.0.0.0:6868"}
-    blobstore: {provider: local, path: /var/vcap/micro_bosh/data/cache}
     ntp:
     - time1.google.com
     - time2.google.com


### PR DESCRIPTION
The CPIs no longer accept blobstore properties.

This will resolve: `connect: connection refused` errors when trying to create-env