### PR TITLE
Add AWS ops file to include a role to be assumed

### DIFF
--- a/aws/cpi-assume-role-credentials.yml
+++ b/aws/cpi-assume-role-credentials.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /cloud_provider/properties/aws/role_arn?
+  value: ((role_arn))


### PR DESCRIPTION
This adds an ops file that allows an assumed role to be used with the authentication in the AWS CPI.  Requires the `role_arn` variable.

For reference:
https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html

[#184999423]