### PR TITLE
[CI] add --no-pager to git commands

### DIFF
--- a/ci/tasks/bump-cpi.sh
+++ b/ci/tasks/bump-cpi.sh
@@ -34,11 +34,11 @@ EOF
 
   local changed=""
   set +e
-  changed="$(git diff --name-only | grep "${iaas}/cpi.yml")"
+  changed="$(git --no-pager diff --name-only | grep "${iaas}/cpi.yml")"
   set -e
 
   if [[ -n "${changed}" ]]; then
-    git diff "${iaas}/cpi.yml"
+    git --no-pager diff "${iaas}/cpi.yml"
 
     git config user.email "cf-infrastructure@pivotal.io"
     git config user.name "cf-infra-bot"

--- a/ci/tasks/bump-stemcell.sh
+++ b/ci/tasks/bump-stemcell.sh
@@ -33,7 +33,7 @@ EOF
     "${iaas}/cpi.yml" > /tmp/cpi.yml
 
   mv /tmp/cpi.yml "${iaas}/cpi.yml"
-  git diff "${iaas}/cpi.yml"
+  git --no-pager diff "${iaas}/cpi.yml"
 }
 
 function main() {


### PR DESCRIPTION
as the docker container we use in our ci task has been bumped to debian:bookworm and therefore a newer git version is used. it outputs commands now in less. to prevent this we need no-pager option